### PR TITLE
Hardening Firebase Rules

### DIFF
--- a/database.rules.json
+++ b/database.rules.json
@@ -1,6 +1,5 @@
 {
   "rules": {
-    ".read": "auth != null",
     "admins":{
       ".read": "auth != null",
       "$uid":{
@@ -66,6 +65,7 @@
       }
     },
     "public_tasks":{
+      ".read": "auth != null",
       ".indexOn": ["userId"],
       "$tid":{
         ".indexOn": ["userId"],


### PR DESCRIPTION
This PR fixes a security issue in the firebase rules.


**Problem**: every authenticated user can read everything, as can be seen in [this report](https://noless.io/report/-L6w8xwYs41qw3Ijr_HB/ab897f9a-4693-441a-9d8c-38998013341e).

**Solution**: I removed the rule `".read": "auth != null"`  from root and put it under `public_tasks` (the only path without direct rules), in order to preserve current functionality.
An analysis on the fixed rules can be [seen here](https://noless.io/report/-L6wEanLTOpN1rIM0oU8/53fa6754-d097-44b0-b684-8a88ec426913).