### PR TITLE
Removed parserOptions from rules section

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,11 +20,6 @@
     "quotes": ["error", "single"],
     "semi": ["error", "never"],
     "react/prop-types": [1],
-    "no-console": "warn",
-    "parserOptions": {
-      "ecmaFeatures": {
-        "jsx": true
-      }
-    }
+    "no-console": "warn"
   }
 }


### PR DESCRIPTION
When a project is created using rmw-react-scripts and imported in Intellij then eslint throws below error because parserOptions is not a valid rule.
So, raised this pull request to remove parserOptions from rules section.

![image](https://user-images.githubusercontent.com/11294278/68548502-bb362900-0413-11ea-858d-d73dc3009e4b.png)
