### PR TITLE
Mix in the path on filters to match watches

### DIFF
--- a/packages/rmw-shell/src/containers/Activities/CollectionActivity.js
+++ b/packages/rmw-shell/src/containers/Activities/CollectionActivity.js
@@ -41,6 +41,7 @@ class CollectionActivity extends Component {
       isGranted,
       list,
       name,
+      path,
       setFilterIsOpen,
       renderItem,
       handleCreateClick,
@@ -63,13 +64,13 @@ class CollectionActivity extends Component {
         title={title ? title : intl.formatMessage({ id: name })}
         appBarContent={
           <div style={{ display: 'flex' }}>
-            <SearchField filterName={name} />
+            <SearchField filterName={path || name} />
             <Tooltip title={intl.formatMessage({ id: 'open_filter' })}>
               <IconButton
                 color="inherit"
                 aria-label="open drawer"
                 onClick={() => {
-                  setFilterIsOpen(name, true)
+                  setFilterIsOpen(path || name, true)
                 }}
               >
                 <FilterList color={hasFilters ? 'secondary' : 'inherit'} />
@@ -105,7 +106,7 @@ class CollectionActivity extends Component {
             </Fab>
           )}
         </div>
-        <FilterDrawer name={name} fields={fields} formatMessage={intl.formatMessage} />
+        <FilterDrawer name={path || name} fields={fields} formatMessage={intl.formatMessage} />
       </Activity>
     )
   }


### PR DESCRIPTION
As proposed in the bug report. When both path and name are set, filters and searches breaks, and this attempts to resolve that.
I haven't error-checked this towards the demo, so please do check that it doesn't create any new issues before merging. It may also be that there's better ways to fix this based on your original design. If so, please feel free to edit. :)