### PR TITLE
added React.forwardRef to container/QuestionDialog Transition

### DIFF
--- a/packages/rmw-shell/src/containers/QuestionDialog/QuestionDialog.js
+++ b/packages/rmw-shell/src/containers/QuestionDialog/QuestionDialog.js
@@ -14,9 +14,9 @@ import { injectIntl } from 'react-intl'
 import { setSimpleValue } from '../../store/simpleValues/actions'
 import getSimpleValue from '../../store/simpleValues/selectors'
 
-function Transition(props) {
-  return <Slide direction="up" {...props} />
-}
+const Transition = React.forwardRef((props, ref) => (
+	<Slide direction='up' {...props} ref={ref} />
+))
 
 class QuestionDialog extends Component {
   handleClose = () => {


### PR DESCRIPTION
...function to resolve invalid prop forwardRef(Modal) issue
This is to resolve the console warning when opening QuestionDialog:
"index.js:1 Warning: Failed prop type: Invalid prop `children` supplied to `ForwardRef(Modal)`. Expected an element that can hold a ref. Did you accidentally use a plain function component for an element instead? For more information see https://material-ui.com/r/caveat-with-refs-guide
    in ForwardRef(Modal) (created by ForwardRef(Dialog))"

Thank you for your powered-up repo Tarik