### PR TITLE
Center loading icon in rmw template

### DIFF
--- a/packages/rmw-shell/cra-template-rmw/template/src/pages/LandingPage/index.js
+++ b/packages/rmw-shell/cra-template-rmw/template/src/pages/LandingPage/index.js
@@ -256,7 +256,19 @@ const LandingPage = () => {
                   </Button>
                 </div>
                 {scrolled && (
-                  <Suspense fallback={<CircularProgress />}>
+                  <Suspense
+                    fallback={
+                      <div
+                        style={{
+                          display: 'flex',
+                          justifyContent: 'center',
+                          marginTop: '125px',    
+                        }}
+                      >
+                        <CircularProgress />
+                      </div>
+                    }
+                  >
                     <PageContent setComponents={setComponents} />
                   </Suspense>
                 )}


### PR DESCRIPTION
Fixes #340

Before:
<img width="1059" alt="Screen Shot 2021-10-31 at 8 13 15 PM" src="https://user-images.githubusercontent.com/40759683/139616907-84675843-d327-485b-b629-3d02cef806d0.png">

After:
<img width="1056" alt="Screen Shot 2021-10-31 at 7 48 46 PM" src="https://user-images.githubusercontent.com/40759683/139616913-cc2de6b5-72e7-412d-a356-4dfcf901064f.png">
