### PR TITLE
chore: Update template to silence build warnings

### DIFF
--- a/packages/bootstrap-shell/cra-template-material-ui/template.json
+++ b/packages/bootstrap-shell/cra-template-material-ui/template.json
@@ -1,7 +1,7 @@
 {
   "package": {
     "dependencies": {
-      "jss": "10.x"
+      "jss": "10.x",
       "jss-rtl": "0.x",
       "@formatjs/intl-relativetimeformat": "8.x",
       "base-shell": "1.x",
@@ -33,7 +33,7 @@
       "@babel/core": "7.x",
       "@types/react": "17.x",
       "typescript": "4.x"
-    }
+    },
     "eslintConfig": {
       "extends": ["react-app", "react-app/jest"]
     }

--- a/packages/bootstrap-shell/cra-template-material-ui/template.json
+++ b/packages/bootstrap-shell/cra-template-material-ui/template.json
@@ -1,6 +1,7 @@
 {
   "package": {
     "dependencies": {
+      "jss": "10.x"
       "jss-rtl": "0.x",
       "@formatjs/intl-relativetimeformat": "8.x",
       "base-shell": "1.x",
@@ -28,6 +29,11 @@
       "react-bootstrap": "2.x",
       "react-bootstrap-icons": "1.x"
     },
+    "devDependencies": {
+      "@babel/core": "7.x",
+      "@types/react": "17.x",
+      "typescript": "4.x"
+    }
     "eslintConfig": {
       "extends": ["react-app", "react-app/jest"]
     }


### PR DESCRIPTION
This will silence the build warnings about unmet peer dependencies

```
warning "@emotion/styled > @emotion/babel-plugin@11.3.0" has unmet peer dependency "@babel/core@^7.0.0".
warning "@emotion/styled > @emotion/babel-plugin > @babel/plugin-syntax-jsx@7.12.13" has unmet peer dependency "@babel/core@^7.0.0-0".
warning " > react-markdown@7.1.0" has unmet peer dependency "@types/react@>=16".
warning "react-scripts > @typescript-eslint/eslint-plugin > tsutils@3.20.0" has unmet peer dependency "typescript@>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta".
```