### PR TITLE
Fix typo in german translation

### DIFF
--- a/packages/material-ui-shell/cra-template-material-ui/template/src/config/locales/de.js
+++ b/packages/material-ui-shell/cra-template-material-ui/template/src/config/locales/de.js
@@ -35,7 +35,7 @@ const messages = defineMessages({
   toast_demo: 'Demo Toast',
   filter_demo: 'Demo filter',
   list_page_demo: 'List Page Demo mit {count} Zeilen',
-  forgot_password: 'Vergessen passwort',
+  forgot_password: 'Passwort vergessen',
   password_reset: 'Passwort zurücksetzen',
   password_confirm: 'Passwortbestätigung',
   registration: 'Registrierung',


### PR DESCRIPTION
Hi, found a typo in the default template - in German we say "Passwort vergessen" instead of "Vergessen Passwort". It follows the same grammatical logic as "Passwort zurücksetzen." (Verb after subject).

Thanks!